### PR TITLE
Linking error fixed, make iso added and gdt implemented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,17 @@ clean:
 
 run: $(TARGETDIR)/$(EXECUTABLE)
 	@qemu-system-x86_64 -kernel $<
-
+iso: $(TARGETDIR)/$(EXECUTABLE)
+	mkdir iso
+	mkdir iso/boot
+	mkdir iso/boot/grub
+	cp bin/kernel iso/boot/
+	echo 'set timeout=0' > iso/boot/grub/grub.cfg
+	echo 'set default=0' >> iso/boot/grub/grub.cfg
+	echo '' >> iso/boot/grub/grub.cfg
+	echo 'menuentry "simplekernel" {' >> iso/boot/grub/grub.cfg
+	echo '  multiboot /boot/kernel' >> iso/boot/grub/grub.cfg
+	echo '	boot'	>> iso/boot/grub/grub.cfg
+	echo '}'	>> iso/boot/grub/grub.cfg
+	grub-mkrescue --output=bin/kernel.iso iso
+	rm -r iso

--- a/include/consts.h
+++ b/include/consts.h
@@ -13,6 +13,6 @@
 #define INTERRUPT_GATE 0x8e
 #define KERNEL_CODE_SEGMENT_OFFSET 0x08
 
-char *vidptr;
+extern char *vidptr;
 
 #endif

--- a/include/screen.h
+++ b/include/screen.h
@@ -3,7 +3,7 @@
 
 #include "consts.h"
 
-unsigned int current_loc;
+extern unsigned int current_loc;
 
 void print_string(const char *string);
 void print_symbol(char symbol);

--- a/src/gdt.asm
+++ b/src/gdt.asm
@@ -1,0 +1,42 @@
+global load_gdt
+
+gdt:
+	gdt_null:
+	dq 0
+	
+	gdt_code:
+	dw 0FFFFh
+	dw 0
+	
+	db 0
+	db 10011010b
+	db 11001111b
+	db 0
+	
+	gdt_data:
+	dw 0FFFFh
+	dw 0
+	
+	db 0
+	db 10010010b
+	db 11001111b
+	db 0
+
+	gdt_end:
+gdt_desc:
+	dw gdt_end - gdt - 1
+	dd gdt
+
+load_gdt:
+	lgdt [gdt_desc]
+	mov ax, 0x10
+	mov ds, ax
+	mov es, ax
+	mov fs, ax
+	mov gs, ax
+	mov ss, ax
+
+	jmp 0x08:flush
+
+flush:
+	retn

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -3,6 +3,7 @@
 #include "keyboard.h"
 #include "screen.h"
 
+extern void load_gdt();
 void kmain(void)
 {
 	const char *str = "Kernel v0.2";
@@ -11,8 +12,14 @@ void kmain(void)
 	print_newline();
 	print_newline();
 
+	load_gdt();
+	print_string("GDT loaded");
+	print_newline();
 	idt_init();
+	print_string("IDT loaded");
+	print_newline();
 	keyboard_init();
-
+	print_string("Keyboard initialized");
+	print_newline();
 	while(1);
 }


### PR DESCRIPTION
I had an error when linking because of multiple definitions of some variables, I fixed them adding the "extern" modificator. I wanted make an iso with GRUB but I got fatal error because GDT was not initialized, I make a simple gdt only to build an ISO.  Now you can test the kernel in a real computer :D. 